### PR TITLE
Fixed sticky button behaviour on touch screens

### DIFF
--- a/components/Quiz/InGame.tsx
+++ b/components/Quiz/InGame.tsx
@@ -114,7 +114,7 @@ const InGame = ({ questions, collectRoundData, setFinalScore, endGame }: InGameP
 
             <ul className="w-full sm:w-3/4 flex flex-row flex-wrap justify-between mt-1">
                 {currentQuestion.answers.map((answer, index) => (
-                    <li className="w-full sm:w-1/2 my-0.5 px-0.5" key={index}>
+                    <li className="w-full sm:w-1/2 my-0.5 px-0.5" key={`${index}${questionNumber}`}>
                         <button
                             className={`
                                     w-full h-11 sm:h-9 rounded select-none text-xl 

--- a/components/Quiz/PostGame.tsx
+++ b/components/Quiz/PostGame.tsx
@@ -2,7 +2,6 @@ import type { GameData } from 'types';
 
 import { useState, useReducer } from 'react';
 import { submitReducer, initialSubmitState } from 'lib/submitReducer';
-import { server } from 'config';
 
 import Spinner from '~/Spinner';
 import Link from 'next/link';
@@ -32,7 +31,7 @@ const PostGame = ({ gameData, finalScore, initGame }: PostGameProps) => {
 
         dispatch({ type: 'submit' });
 
-        const response = await fetch(`${server}/api/scores`, {
+        const response = await fetch(`/api/scores`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({

--- a/components/Quiz/Quiz.tsx
+++ b/components/Quiz/Quiz.tsx
@@ -1,7 +1,6 @@
 import type { QuestionType, GameData, RoundData } from 'types';
 
 import { useState } from 'react';
-import { server } from 'config';
 
 import PreGame from './PreGame';
 import Countdown from './Countdown';
@@ -21,7 +20,7 @@ const Quiz = () => {
     const [finalScore, setFinalScore] = useState(0);
 
     const initGame = async () => {
-        const response = await fetch(`${server}/api/questions`);
+        const response = await fetch(`/api/questions`);
         const data: ApiResponse = await response.json();
         setQuestions(data.questions);
         setGameData([]);

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,3 +1,5 @@
 const dev = process.env.NODE_ENV !== 'production';
 
-export const server = dev ? 'http://localhost:3000' : process.env.VERCEL_URL;
+export const server = dev
+    ? 'http://localhost:3000'
+    : process.env.VERCEL_URL || 'https://pasta.kfirfitousi.com';

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,3 +1,3 @@
 const dev = process.env.NODE_ENV !== 'production';
 
-export const server = dev ? 'http://localhost:3000' : 'https://pasta.kfirfitousi.com';
+export const server = dev ? 'http://localhost:3000' : process.env.VERCEL_URL;

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,5 +1,0 @@
-const dev = process.env.NODE_ENV !== 'production';
-
-export const server = dev
-    ? 'http://localhost:3000'
-    : process.env.VERCEL_URL || 'https://pasta.kfirfitousi.com';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,14 +1,12 @@
 import type { AppProps } from 'next/app';
 
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
 
 import Spinner from '~/Spinner';
 
 import 'styles/globals.css';
 
-const PastaQuiz = ({ Component, pageProps }: AppProps) => {
-    const router = useRouter();
+const PastaQuiz = ({ Component, pageProps, router }: AppProps) => {
     const [isLoading, setIsLoading] = useState(false);
 
     useEffect(() => {


### PR DESCRIPTION
This PR fixes an issue where buttons in the Quiz component remained in pressed state after tap.
The problem was using `key={index}` when mapping the answers to buttons, because it means the buttons don't re-render when a new round begins.
Changing to ``key={`${index}${questionNumber}`}`` makes the key unique every round and fixes the issue.